### PR TITLE
Adding Port field on configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The `mongodb.Conf` use a YAML tags, it's easy to load MongoDB config with config
 type Conf struct {
 	DB         string `yaml:"db"`          // Name of the database.
 	Host       string `yaml:"host"`        // URL to reach the mongoDB server.
+	Port       int    `yaml:"port,omitempty"` // Optionnal port, if set to 0 it won't be processed.
 	Username   string `yaml:"username"`    // Credential to authenticate to the db.
 	Password   string `yaml:"password"`    // Credential to authenticate to the db.
 	AuthSource string `yaml:"auth_source"` // Database to check authentication

--- a/connector.go
+++ b/connector.go
@@ -13,7 +13,7 @@ import (
 type Conf struct {
 	DB         string `yaml:"db"`             // Name of the database.
 	Host       string `yaml:"host"`           // URL to reach the mongoDB server.
-	Port       int    `yaml:"port,omitempty"` // Optionnal port.
+	Port       int    `yaml:"port,omitempty"` // Optionnal port, if set to 0 it won't be processed.
 	Username   string `yaml:"username"`       // Credential to authenticate to the db.
 	Password   string `yaml:"password"`       // Credential to authenticate to the db.
 	AuthSource string `yaml:"auth_source"`    // Database to check authentication

--- a/connector.go
+++ b/connector.go
@@ -11,12 +11,13 @@ import (
 
 // Conf contains all information to connect to a MongoDB server.
 type Conf struct {
-	DB         string `yaml:"db"`          // Name of the database.
-	Host       string `yaml:"host"`        // URL to reach the mongoDB server.
-	Username   string `yaml:"username"`    // Credential to authenticate to the db.
-	Password   string `yaml:"password"`    // Credential to authenticate to the db.
-	AuthSource string `yaml:"auth_source"` // Database to check authentication
-	Timeout    int    `yaml:"timeout"`     // Connection timeout in seconds
+	DB         string `yaml:"db"`             // Name of the database.
+	Host       string `yaml:"host"`           // URL to reach the mongoDB server.
+	Port       int    `yaml:"port,omitempty"` // Optionnal port.
+	Username   string `yaml:"username"`       // Credential to authenticate to the db.
+	Password   string `yaml:"password"`       // Credential to authenticate to the db.
+	AuthSource string `yaml:"auth_source"`    // Database to check authentication
+	Timeout    int    `yaml:"timeout"`        // Connection timeout in seconds
 }
 
 // Connector is the connector used to communicate with MongoDB database server.
@@ -44,6 +45,10 @@ func (con *Connector) TryConnection() error {
 // FactoryConnector instanciates a new *Connector with the given params.
 func FactoryConnector(c Conf) (*Connector, error) {
 	connectionURI := fmt.Sprintf("mongodb+srv://%s:%s@%s/%s?retryWrites=true&w=majority", c.Username, c.Password, c.Host, c.AuthSource)
+	if c.Port != 0 {
+		connectionURI = fmt.Sprintf("mongodb://%s:%s@%s/%s?retryWrites=true&w=majority", c.Username, c.Password, c.Host, c.AuthSource)
+
+	}
 
 	serverAPI := options.ServerAPI(options.ServerAPIVersion1)
 

--- a/connector_test.go
+++ b/connector_test.go
@@ -134,6 +134,21 @@ func TestFactoryConnector(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Success case with port",
+			args: args{
+				c: Conf{
+					DB:         defaultClient.DB,
+					Host:       defaultConfig.Host,
+					Port:       27017,
+					Username:   defaultConfig.Username,
+					Password:   defaultConfig.Password,
+					AuthSource: defaultConfig.AuthSource,
+					Timeout:    defaultConfig.Timeout,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "Fail case: wrong Host",
 			args: args{
 				c: Conf{


### PR DESCRIPTION
Add Conf.Port field to allow connection to mongo instance reachable with <host>:<port>